### PR TITLE
readme: clarify how to provide the webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,13 @@ The main features are:
 - JavaScript strings for embedding environment variables or custom logic into notification strings
 - Easy to add fields based on standard Slack JSON inputs
 
-Be sure that you set the `SLACK_WEBHOOK_URL` environment variable, either in the job or in the step.
+Be sure that you set the `SLACK_WEBHOOK_URL` environment variable, either in the job or in the step like this:
+
+```yaml
+- uses: adamkdean/simple-slack-notify@master
+  env:
+    SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+```
 
 ## Example usage
 


### PR DESCRIPTION
A clearer example was given at https://dev.to/adamkdean/slack-notifications-with-github-actions-1lk5 but not in the README and, to my shame, it left me puzzled a bit.

To spare the next dev some time … 😏